### PR TITLE
Use API V8 instead of V1 to retrieve camera list

### DIFF
--- a/DiskStation/DiskstationConnect.groovy
+++ b/DiskStation/DiskstationConnect.groovy
@@ -222,7 +222,7 @@ def getDSInfo() {
     executeLoginCommand()
 
     // get cameras
-    queueDiskstationCommand("SYNO.SurveillanceStation.Camera", "List", "additional=device", 1)
+    queueDiskstationCommand("SYNO.SurveillanceStation.Camera", "List", "additional=device&basic=true", 8)
 }
 
 def executeLoginCommand() {


### PR DESCRIPTION
API V1 returns too much information for Smartthings